### PR TITLE
Import escape from markupsafe if not found in jinja2.

### DIFF
--- a/http/app.py
+++ b/http/app.py
@@ -11,7 +11,11 @@ try:
 except ImportError:
     from urllib.parse import urlparse, urljoin
 
-from jinja2 import escape
+try:
+    from jinja2 import escape
+except ImportError:
+    from markupsafe import escape
+
 from jinja2.utils import generate_lorem_ipsum
 from flask import Flask, make_response, request, redirect, url_for, abort, session, jsonify
 


### PR DESCRIPTION
Noticed with latest Flask/jinja2 versions.